### PR TITLE
Fix bar text artefacts

### DIFF
--- a/app/assets/javascripts/glimpse/views/performance_bar.coffee
+++ b/app/assets/javascripts/glimpse/views/performance_bar.coffee
@@ -94,7 +94,7 @@ class PerformanceBar
     left = @mapH(offset)
     width = @mapH(time)
 
-    bar = $("<li class='tooltip'>#{name}</li>")
+    bar = $("<li class='tooltip'></li>")
     title = "#{name}: #{PerformanceBar.formatTime(time)}"
     title += "\n\n#{info}".replace(/\n/g, '<br/>') if info
     bar.attr 'title', title
@@ -102,7 +102,7 @@ class PerformanceBar
       width: "#{width}px"
       left:  "#{left}px"
       background: color
-    bar.tipsy gravity: 'n', html: true
+    bar.tipsy gravity: 'n'
     @el.append bar
 
   # Map a time offset value to a horizontal pixel offset.


### PR DESCRIPTION
I had problems with the text edges showing up in the performance bar regardless of the transparent font color.

![Screenshot from 2013-03-16 23:17:01](https://f.cloud.github.com/assets/1098408/267444/4b47ccb0-8e87-11e2-8c84-8693df51af0d.png)
![Screenshot from 2013-03-16 23:16:27](https://f.cloud.github.com/assets/1098408/267445/50f76288-8e87-11e2-9337-cdc5a4ab8c26.png)

This hides the bar segment text completely with font-size, in addition to the color.
