### PR TITLE
Fix bug displaying total navigation time.

### DIFF
--- a/app/assets/stylesheets/glimpse/views/performance_bar.scss
+++ b/app/assets/stylesheets/glimpse/views/performance_bar.scss
@@ -12,7 +12,6 @@
   box-shadow: 0 1px 0 rgba(255, 255, 255, .15);
 
   li {
-    position: absolute;
     top: 0;
     bottom: 0;
     overflow: hidden;


### PR DESCRIPTION
Before: 
![Screen Shot 2013-03-18 at 12 53 48 AM](https://f.cloud.github.com/assets/2035/269148/7de6b23c-8f7f-11e2-9945-bfd5579469db.png)

After:
![Screen Shot 2013-03-18 at 12 53 55 AM](https://f.cloud.github.com/assets/2035/269149/86aee0f6-8f7f-11e2-8cc3-26a441fa6c1b.png)
