### PR TITLE
Change tooltip class name to avoid conflicts.

### DIFF
--- a/app/assets/javascripts/glimpse/views/performance_bar.coffee
+++ b/app/assets/javascripts/glimpse/views/performance_bar.coffee
@@ -32,7 +32,7 @@ class PerformanceBar
     @el = $('.performance-bar')
     @[k] = v for k, v of options
     @width  ?= @el.width()
-    @timing ?= window.performance?.timing
+    @timing ?= window.performance.timing
 
   # Render the performance bar in the associated element. This is a little weird
   # because it includes the server-side rendering time reported with the


### PR DESCRIPTION
It's a better solution for the same problem found here: https://github.com/dewski/glimpse-performance_bar/pull/6
