### PR TITLE
support custom events to trigger update

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,22 @@ CoffeeScript:
 #= require peek/views/performance_bar
 ```
 
+## Measuring Ajax performance
+
+If you're using Pjax or Turbolinks, you don't need to do anything more than
+what is documented above.
+
+For custom Ajax events, Peek::PerformanceBar supports custom `peek:start` and
+`peek:end` events.
+
+For example, you could do something like this to update the performance bar
+for all Ajax requests made through jQuery:
+
+```ruby
+$(document).on('ajax:send', function() { $(this).trigger('peek:start') })
+$(document).on('ajax:complete', function() { $(this).trigger('peek:end') })
+```
+
 ## Contributors
 
 - [@josh](https://github.com/josh) - The original implementation.
@@ -58,6 +74,7 @@ CoffeeScript:
 - [@rtomayko](https://github.com/rtomayko) - The original implementation.
 - [@kneath](https://github.com/kneath) - The original implementation.
 - [@dewski](https://github.com/dewski) - Just the extractor.
+- [@barunio](https://github.com/barunio) - Ajax support.
 
 ## Contributing
 

--- a/app/assets/javascripts/peek/views/performance_bar.coffee
+++ b/app/assets/javascripts/peek/views/performance_bar.coffee
@@ -124,10 +124,10 @@ updateStatus = (html) ->
   $('#serverstats').html html
 
 ajaxStart = null
-$(document).on 'pjax:start page:fetch', (event) ->
+$(document).on 'peek:start pjax:start page:fetch', (event) ->
   ajaxStart = event.timeStamp
 
-$(document).on 'pjax:end page:change', (event, xhr) ->
+$(document).on 'peek:end pjax:end page:change', (event, xhr) ->
   ajaxEnd    = event.timeStamp
   total      = ajaxEnd - ajaxStart
   serverTime = if xhr then parseInt(xhr.getResponseHeader('X-Runtime')) else 0


### PR DESCRIPTION
This PR provides a way to use peek-performance_bar with standard Ajax requests that are not carried out via Pjax or Turbolinks, simply by supporting custom `peek:start` and `peek:end` events.

For example, you could do something like this to update the performance bar for all Ajax requests:

``` javascript
$(document).on('ajax:send', function() { $(this).trigger('peek:start') })
$(document).on('ajax:complete', function() { $(this).trigger('peek:end') })
```
