### PR TITLE
Closes peek/peek-performance_bar#16: Fixing incorrect time on initial page load with Turbolinks

### DIFF
--- a/app/assets/javascripts/peek/views/performance_bar.coffee
+++ b/app/assets/javascripts/peek/views/performance_bar.coffee
@@ -127,7 +127,7 @@ ajaxStart = null
 $(document).on 'pjax:start page:fetch', (event) ->
   ajaxStart = event.timeStamp
 
-$(document).on 'pjax:end page:change', (event, xhr) ->
+$(document).on 'pjax:end page:load', (event, xhr) ->
   ajaxEnd    = event.timeStamp
   total      = ajaxEnd - ajaxStart
   serverTime = if xhr then parseInt(xhr.getResponseHeader('X-Runtime')) else 0


### PR DESCRIPTION
In Turbolinks 2.0 the `page:change` event was changed to be fired on initial page load, which caused the time output to be incorrect because it wasn't actually a Turbolinks request. The solution appears to be to hook into the `page:load` event, which is only fired when a Turbolinks request is actually made.
