### PR TITLE
Allow `PerformanceBar::ProcessUtilization::Body` to behave like normal response body

### DIFF
--- a/lib/peek/views/performance_bar/process_utilization.rb
+++ b/lib/peek/views/performance_bar/process_utilization.rb
@@ -124,7 +124,7 @@ module Peek
           
           # Delegate calls to @body to be compatible with other middlewares
           def method_missing(name, *args, &block)
-            super unless @body.response_to?(name)
+            super unless @body.respond_to?(name)
             
             @body.send(name, *args, &block)
           end

--- a/lib/peek/views/performance_bar/process_utilization.rb
+++ b/lib/peek/views/performance_bar/process_utilization.rb
@@ -121,6 +121,13 @@ module Peek
             @block.call
             nil
           end
+          
+          # Delegate calls to @body to be compatible with other middlewares
+          def method_missing(name, *args, &block)
+            super unless @body.response_to?(name)
+            
+            @body.send(name, *args, &block)
+          end
         end
 
         # Rack entry point.


### PR DESCRIPTION
…ve like normal response body

Currently `Peek::Views::PerformanceBar::ProcessUtilization::Body` wraps response body from middleware stack but not really compatible with other middlewares which needs to get body contents, like https://github.com/peek/peek-performance_bar/issues/19

This PR delegates all calls to the original response body to prevent above issue from happening.