### PR TITLE
We don't need to hold @env and it's bad to hold it

### DIFF
--- a/lib/peek/views/performance_bar/process_utilization.rb
+++ b/lib/peek/views/performance_bar/process_utilization.rb
@@ -108,7 +108,6 @@ module Peek
 
         # Rack entry point.
         def call(env)
-          @env = env
           reset_stats
 
           @total_requests += 1


### PR DESCRIPTION
Because the Rack app and middleware would never be garbage collected,
if we hold the @env then it would always hold the information for the
last request, which could be heavy. Don't hold it so that the request
could be garbage collected.

Please review? Thanks!