### PR TITLE
fix ajax timing calculation

### DIFF
--- a/app/assets/javascripts/peek/views/performance_bar.js
+++ b/app/assets/javascripts/peek/views/performance_bar.js
@@ -152,7 +152,7 @@ $(document).on('pjax:end page:load turbolinks:load', function(event, xhr) {
   // Defer to include the timing of pjax hook evaluation
   return setTimeout(function() {
     let tech;
-    let now = new Date().getTime();
+    let now = performance.now()
     let bar = new PerformanceBar({
       timing: {
         requestStart: ajaxStart,


### PR DESCRIPTION
ajax timings are derived from `event.timeStamp` values. latest browser improvements in anti-fingerprinting measures made APIs return timestamps with reduced time precision. calculating timings with those values with `new Date().getTime()` will blow up because it returns a different precision value. the solution is to use `performance.now()` in place of `Date()`

https://developer.mozilla.org/en-US/docs/Web/API/Event/timeStamp https://developer.mozilla.org/en-US/docs/Web/API/DOMHighResTimeStamp https://developer.mozilla.org/en-US/docs/Web/API/Performance/now

should resolve #33
should resolve #25

possibly breaking change for older browsers. do we care about those?